### PR TITLE
Update dependencies and fix pom.xml version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>rdiger36</groupId>
     <artifactId>StudioBridge</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <packaging>jar</packaging>
 
     <name>StudioBridge</name>
@@ -17,9 +17,9 @@
 
         <!-- Dependency Versions -->
         <flatlaf.version>3.7.1</flatlaf.version>
-        <commons-io.version>2.21.0</commons-io.version>
-        <jna.version>5.18.1</jna.version>
-        <json.version>20250517</json.version>
+        <commons-io.version>2.22.0</commons-io.version>
+        <jna.version>5.19.0</jna.version>
+        <json.version>20260522</json.version>
         <junit.version>4.13.2</junit.version>
         <jnafilechooser.version>1.1.2</jnafilechooser.version>
     </properties>
@@ -36,6 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>


### PR DESCRIPTION
## Summary

- Bumped **commons-io** from `2.21.0` to `2.22.0`
- Bumped **jna** and **jna-platform** from `5.18.1` to `5.19.0`
- Bumped **org.json** from `20250517` to `20260522`
- Fixed `pom.xml` project version from `2.1.0` to `2.1.1` to align with the app version string in `MainMenu.java`
- Pinned `maven-compiler-plugin` to version `3.13.0` to resolve Maven build warning about missing plugin version

## Security

All dependencies were checked against the GitHub Advisory Database and the OSV database — no known vulnerabilities found. Previous `org.json` CVEs (HIGH) were already patched in versions prior to our baseline.

## Test plan

- [x] Build passes with `mvn clean package`
- [x] App starts and functions correctly
- [x] No new Maven warnings during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)