### PR TITLE
drop: remove macOS Intel (x86) build

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -289,7 +289,11 @@ jobs:
           path: "*.AppImage"
 
   # ─────────────────────────────────────────────────────────────────────────
-  # macOS — signed + notarized DMG  (arm64 and x86)
+  # macOS — signed + notarized DMG  (arm64 / Apple Silicon only)
+  #
+  # Intel (x86) support dropped: macOS 27 (September 2026) removes Rosetta 2,
+  # making x86 app execution on Apple Silicon impossible. Intel Macs cannot
+  # upgrade to macOS 27, so the x86 user base will effectively be zero.
   #
   # Required secrets:
   #   MACOS_CERTIFICATE     — base64-encoded Developer ID Application .p12
@@ -303,15 +307,7 @@ jobs:
   build-macos:
     needs: build-jar
     if: startsWith(github.ref, 'refs/tags/v')
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: macos-latest   # arm64 — M-Series
-            arch: arm64
-          - runner: macos-13       # x86   — Intel
-            arch: x86
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-latest   # arm64 — Apple Silicon (M-Series)
     steps:
       - uses: actions/checkout@v4
 
@@ -424,7 +420,7 @@ jobs:
       - name: Rename DMG
         run: |
           V="${{ needs.build-jar.outputs.version }}"
-          mv dmg-output/*.dmg "StudioBridge-${V}_macOS_${{ matrix.arch }}.dmg"
+          mv dmg-output/*.dmg "StudioBridge-${V}_macOS_arm64.dmg"
 
       - name: Notarize and staple DMG
         env:
@@ -459,7 +455,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: macos-${{ matrix.arch }}
+          name: macos-arm64
           path: "*.dmg"
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -485,7 +481,6 @@ jobs:
             artifacts/linux-x86_64/*
             artifacts/linux-aarch64/*
             artifacts/macos-arm64/*
-            artifacts/macos-x86/*
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
         env:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@
   <img src="https://img.shields.io/badge/maintained-yes-brightgreen?style=flat-square" alt="maintained" />
 </p>
 
+<p align="center">
+  <img src="https://img.shields.io/github/stars/Rdiger-36/StudioBridge?style=flat-square&color=yellow" alt="stars" />
+  <img src="https://img.shields.io/github/forks/Rdiger-36/StudioBridge?style=flat-square&color=orange" alt="forks" />
+  <img src="https://img.shields.io/github/issues/Rdiger-36/StudioBridge?style=flat-square" alt="open issues" />
+  <img src="https://img.shields.io/github/downloads/Rdiger-36/StudioBridge/total?style=flat-square&label=downloads&color=blue" alt="total downloads" />
+  <img src="https://img.shields.io/github/last-commit/Rdiger-36/StudioBridge?style=flat-square&label=last%20commit" alt="last commit" />
+</p>
+
 ---
 
 With StudioBridge it is possible to make Bambu Lab 3D Printers visible in Bambu Studio or Orca Slicer, that can not be automatically added by them.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,27 @@
-# StudioBridge
+<p align="center">
+  <img src=".github/packaging/icons/icon.png" width="120" alt="StudioBridge icon" />
+</p>
 
-With StudioBridge it is possible to make Bambu Lab 3D Printers visible in Bambu Studio or Orca Slicer, that can not be automatically added by them.  
-It is also possible to conenct printers from other subnets or from accessible external networks (e.g. via VPN) or in your normal home network.
+<h1 align="center">StudioBridge</h1>
+
+<p align="center">
+  Make your Bambu Lab 3D printers visible in Bambu Studio or Orca Slicer — across any network.<br/>
+  Connect printers from other subnets, VPNs, or your home network with a simple GUI.
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/github/v/release/Rdiger-36/StudioBridge?style=flat-square&label=version&color=blue" alt="version" />
+  <img src="https://img.shields.io/badge/Java-%E2%89%A521-ED8B00?style=flat-square&logo=openjdk&logoColor=white" alt="Java" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-lightgrey?style=flat-square" alt="platform" />
+  <img src="https://img.shields.io/badge/license-GPL--3.0-green?style=flat-square" alt="license" />
+  <img src="https://img.shields.io/github/actions/workflow/status/Rdiger-36/StudioBridge/build-and-release.yml?style=flat-square&label=build" alt="build" />
+  <img src="https://img.shields.io/badge/maintained-yes-brightgreen?style=flat-square" alt="maintained" />
+</p>
+
+---
+
+With StudioBridge it is possible to make Bambu Lab 3D Printers visible in Bambu Studio or Orca Slicer, that can not be automatically added by them.
+It is also possible to connect printers from other subnets or from accessible external networks (e.g. via VPN) or in your normal home network.
 There are many scripts for all kinds of systems, but many users feel more comfortable with a GUI. Therefore I developed StudioBridge, which is basically based on the scripts i found in countless forums.
 
 # How it works

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ You can check if the printer would connect correctly in Bambu Studio with the fu
 Successfully tested on:
 - Windows 10/11 ARM and x86
 - Linux Ubuntu 25.10 ARM and x86
-- MacOS Intel and M-Series
+- macOS M-Series (Apple Silicon)
+
+> **Note for Intel Mac users:** macOS 27 (September 2026) removes Rosetta 2 support. Native Intel (x86) builds are no longer provided. Intel Mac users can use the `.jar` release with Java 21+.
 
 # Requirements
 - min. Java 21 (only for .jar compiled release)
@@ -202,13 +204,6 @@ Running the StudioBridge GUI
 	3.	Double-click the .jar file to launch StudioBridge. This should open the GUI, allowing you to configure and use your 3D printers with Bambu Studio over LAN.
 
 If the .jar file does not open directly, ensure Java is properly installed, and check your system’s default settings for opening .jar files.
-
-## FAQ
-Q: My app won't start on macOS. There is an error message saying that the app is corrupted and needs to be deleted.
-
-A: This is a safety feature from macOS Gatekeeper. To disable this error message, run the following command in your terminal:
-
-`xattr -dr com.apple.quarantine /Applications/StudioBridge.app`
 
 # Support Me
 [![Buy Me a Coffee](https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png)](https://www.buymeacoffee.com/Rdiger36)


### PR DESCRIPTION
## Summary

- **Remove `macos-13` runner** from build-macos matrix — only `macos-latest` (Apple Silicon, arm64) remains
- **Fix artifact/DMG names** — hardcoded `arm64` instead of `${{ matrix.arch }}`
- **Update README** — macOS support note changed to M-Series only; added info note for Intel Mac users pointing to the `.jar` release
- **Remove Gatekeeper workaround FAQ** — no longer needed since the app is signed and notarized

## Reason

macOS 27 (September 2026, ~3 months away) removes Rosetta 2. Once that ships:
- Intel Macs cannot upgrade to macOS 27 (Apple drops old hardware)
- Apple Silicon Macs can no longer run x86 apps
- The `macos-13` GitHub Actions runner has very long queue times and will eventually be retired

Intel Mac users can use the `.jar` release with Java 21+.

## Test plan

- [ ] Merge and push test tag `v.2.1.1-test4`
- [ ] Verify only one macOS build runs (arm64, macos-latest)
- [ ] Verify DMG filename is `StudioBridge-2.1.1_macOS_arm64.dmg`
- [ ] Confirm pre-release flag is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)