### PR TITLE
chore: bump version to 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To use StudioBridge via Terminal/CMD/PowerShell you have to run the StudioBridge
 
 /Applications/StudioBridge.app/Contents/MacOS/StudioBridgeCLI --help
 
-*** StudioBridge by Rdiger-36 v.2.1.0 ***
+*** StudioBridge by Rdiger-36 v.2.1.2 ***
 
 Usage:
   /Applications/StudioBridge.app/Contents/MacOS/StudioBridgeCLI [OPTIONS]
@@ -122,7 +122,7 @@ You can find the StudioBridgeCLI.exe in your installation directory, standard: "
 ```bash
 .\StudioBridgeCLI.exe --help
 
-*** StudioBridge by Rdiger-36 v.2.1.0 ***
+*** StudioBridge by Rdiger-36 v.2.1.2 ***
 
 You are currently running this application in raw mode (via .jar)!
 For the official version for your OS and CPU architecture, please visit the GitHub repository.
@@ -158,7 +158,7 @@ Example:
 ```bash
 .\StudioBridge.AppImage --help
 
-*** StudioBridge by Rdiger-36 v.2.1.0 ***
+*** StudioBridge by Rdiger-36 v.2.1.2 ***
 
 You are currently running this application in raw mode (via .jar)!
 For the official version for your OS and CPU architecture, please visit the GitHub repository.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>rdiger36</groupId>
     <artifactId>StudioBridge</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
     <packaging>jar</packaging>
 
     <name>StudioBridge</name>

--- a/src/main/java/rdiger36/StudioBridge/gui/MainMenu.java
+++ b/src/main/java/rdiger36/StudioBridge/gui/MainMenu.java
@@ -72,7 +72,7 @@ public class MainMenu {
     public static String title = "StudioBridge";
     
     // Application version
-    public static String version = "211";
+    public static String version = "212";
     
     // Destination for UDPPackage
     public static String destionation4UDP = "localhost";


### PR DESCRIPTION
## Summary

Bumps the project version from 2.1.1 → 2.1.2.

| File | Change |
|------|--------|
| `pom.xml` | `<version>2.1.1</version>` → `2.1.2` |
| `MainMenu.java` | `version = "211"` → `"212"` |
| `README.md` | CLI example output updated to `v.2.1.2` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)