### PR TITLE
feat: add Bambu Lab A2L support

### DIFF
--- a/src/main/java/rdiger36/StudioBridge/functions/Models.java
+++ b/src/main/java/rdiger36/StudioBridge/functions/Models.java
@@ -12,6 +12,7 @@ public class Models {
         switch (model) {
             case "A1": model = "N2S"; break;
             case "A1 Mini": model = "N1"; break;
+            case "A2L": model = "N9"; break;
             case "P1P": model = "C11"; break;
             case "P1S": model = "C12"; break;
             case "P2S": model = "N7"; break;
@@ -40,6 +41,7 @@ public class Models {
         switch (model) {
 	        case "N2S": model = "A1"; break;
 	        case "N1": model = "A1 Mini"; break;
+	        case "N9": model = "A2L"; break;
 	        case "C11": model = "P1P"; break;
 	        case "C12": model = "P1S"; break;
 	        case "N7": model = "P2S"; break;

--- a/src/main/java/rdiger36/StudioBridge/gui/MainMenu.java
+++ b/src/main/java/rdiger36/StudioBridge/gui/MainMenu.java
@@ -527,7 +527,7 @@ public class MainMenu {
         frmStudioBridge.getContentPane().add(lblDevModel, "flowx,cell 0 5,growx,aligny center");
 
         String[] items = {
-        	    "A-Series", "A1", "A1 Mini",
+        	    "A-Series", "A1", "A1 Mini", "A2L",
         	    "H-Series", "H2C", "H2C (new revision)", "H2D", "H2D Pro", "H2S",
         	    "P-Series", "P1P", "P1S", "P2S",
         	    "X-Series", "X1", "X1C", "X1E", "X2D"


### PR DESCRIPTION
## Summary

Adds the Bambu Lab A2L as a supported printer model.

| Display name | Model code |
|---|---|
| A2L | N9 |

**Changes:**
- `Models.java`: bidirectional mapping A2L ↔ N9 added
- `MainMenu.java`: A2L added to the A-Series dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)