### PR TITLE
fix(profiles): keep profiles path in sync with migrated data directory

### DIFF
--- a/src/main/java/rdiger36/StudioBridge/gui/MainMenu.java
+++ b/src/main/java/rdiger36/StudioBridge/gui/MainMenu.java
@@ -132,6 +132,7 @@ public class MainMenu {
 
         migrateOldDataDirectory();
         Config.loadAppSettings();
+        migrateLegacyProfilesPathSetting();
 
         final Map<String, String> valid = new LinkedHashMap<>();
 
@@ -315,6 +316,51 @@ public class MainMenu {
         newDir.mkdirs();
         mergeDirectories(oldDir, newDir);
         deleteDirectory(oldDir);
+    }
+
+    /**
+     * Repairs a profiles path that was read from the settings file but still points into
+     * the old data directory that {@link #migrateOldDataDirectory()} has already moved.
+     *
+     * <p>The settings file always contains an absolute {@code customProfilesPath}, even for
+     * users who never picked one, so everybody who used StudioBridge before the data
+     * directory was renamed has the old location stored there. Because the settings are
+     * loaded after the directory migration, that stored value overrides the migrated path
+     * and the profiles moved to the new directory are never found again.</p>
+     *
+     * <p>This runs on every start and does not require the old directory to still exist,
+     * because {@code getAllProfiles()} recreates the missing directory as an empty one.</p>
+     */
+    private static void migrateLegacyProfilesPathSetting() {
+        String legacyDir = System.getProperty("user.home") + System.getProperty("file.separator") + "StudioBridge";
+        ProfilesDir = remapLegacyProfilesPath(ProfilesDir, legacyDir, defaultSavePath);
+    }
+
+    /**
+     * Moves a path that lies inside the old data directory to the same relative location
+     * inside the current one. Paths outside the old directory are returned unchanged, so a
+     * directory the user deliberately selected somewhere else is kept as it is.
+     *
+     * @param profilesDir the profiles path as loaded from the settings file.
+     * @param legacyDir the data directory used before the rename.
+     * @param currentDir the data directory used today.
+     * @return the remapped path, or the unchanged path if no remapping is needed.
+     */
+    static String remapLegacyProfilesPath(String profilesDir, String legacyDir, String currentDir) {
+        if (profilesDir == null || legacyDir == null || currentDir == null) {
+            return profilesDir;
+        }
+
+        if (profilesDir.equals(legacyDir)) {
+            return currentDir;
+        }
+
+        // Compare including the separator so that siblings like "StudioBridgeBackup" are not matched
+        if (profilesDir.startsWith(legacyDir + System.getProperty("file.separator"))) {
+            return currentDir + profilesDir.substring(legacyDir.length());
+        }
+
+        return profilesDir;
     }
 
     private static void mergeDirectories(File src, File dest) {

--- a/src/test/java/rdiger36/StudioBridge/gui/MainMenuTest.java
+++ b/src/test/java/rdiger36/StudioBridge/gui/MainMenuTest.java
@@ -1,0 +1,84 @@
+package rdiger36.StudioBridge.gui;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests for the remapping of profile paths that were stored in the settings file
+ * before the data directory was renamed from "StudioBridge" to ".studio-bridge".
+ */
+public class MainMenuTest {
+
+    private static final String SEP = System.getProperty("file.separator");
+    private static final String LEGACY_DIR = SEP + "home" + SEP + "user" + SEP + "StudioBridge";
+    private static final String CURRENT_DIR = SEP + "home" + SEP + "user" + SEP + ".studio-bridge";
+
+    /**
+     * The default profiles directory of an old installation has to end up in the new
+     * data directory. This is the case reported in issue #25.
+     */
+    @Test
+    public void remapsDefaultProfilesDirectoryOfOldInstallations() {
+        assertEquals(CURRENT_DIR + SEP + "Profiles",
+                MainMenu.remapLegacyProfilesPath(LEGACY_DIR + SEP + "Profiles", LEGACY_DIR, CURRENT_DIR));
+    }
+
+    /**
+     * A path pointing at the old data directory itself is remapped to the new one.
+     */
+    @Test
+    public void remapsLegacyDirectoryItself() {
+        assertEquals(CURRENT_DIR,
+                MainMenu.remapLegacyProfilesPath(LEGACY_DIR, LEGACY_DIR, CURRENT_DIR));
+    }
+
+    /**
+     * Sub directories keep their relative position, because the directory migration
+     * merges them recursively.
+     */
+    @Test
+    public void keepsRelativePositionOfNestedDirectories() {
+        assertEquals(CURRENT_DIR + SEP + "My" + SEP + "Profiles",
+                MainMenu.remapLegacyProfilesPath(LEGACY_DIR + SEP + "My" + SEP + "Profiles", LEGACY_DIR, CURRENT_DIR));
+    }
+
+    /**
+     * A directory the user selected somewhere else must not be touched.
+     */
+    @Test
+    public void keepsCustomDirectoriesOutsideTheLegacyDirectory() {
+        String custom = SEP + "home" + SEP + "user" + SEP + "Documents" + SEP + "Profiles";
+
+        assertEquals(custom, MainMenu.remapLegacyProfilesPath(custom, LEGACY_DIR, CURRENT_DIR));
+    }
+
+    /**
+     * A directory that only shares its prefix with the old data directory is not a match.
+     */
+    @Test
+    public void doesNotMatchSiblingDirectoriesSharingThePrefix() {
+        String sibling = LEGACY_DIR + "Backup" + SEP + "Profiles";
+
+        assertEquals(sibling, MainMenu.remapLegacyProfilesPath(sibling, LEGACY_DIR, CURRENT_DIR));
+    }
+
+    /**
+     * Running the remapping again on an already migrated path changes nothing, so it is
+     * safe to execute it on every start.
+     */
+    @Test
+    public void isIdempotentForAlreadyMigratedPaths() {
+        String migrated = CURRENT_DIR + SEP + "Profiles";
+
+        assertEquals(migrated, MainMenu.remapLegacyProfilesPath(migrated, LEGACY_DIR, CURRENT_DIR));
+    }
+
+    /**
+     * A missing path must not cause a failure during startup.
+     */
+    @Test
+    public void keepsNullPathUntouched() {
+        assertEquals(null, MainMenu.remapLegacyProfilesPath(null, LEGACY_DIR, CURRENT_DIR));
+    }
+}


### PR DESCRIPTION
Fixes #25

## Problem

Profiles created after upgrading disappear on every restart. The profile files are not actually lost — they end up in `~/.studio-bridge/Profiles`, but the application never reads them from there again, and an empty profile directory is recreated on every start.

## Root cause

Renaming the data directory to `.studio-bridge` (#23) came with `migrateOldDataDirectory()`, which moves the files from `~/StudioBridge` and deletes the old directory. Two details defeat it:

1. `Config.saveUserSettings()` writes `customProfilesPath` **unconditionally** ([`Config.java#L308`](https://github.com/Rdiger-36/StudioBridge/blob/main/src/main/java/rdiger36/StudioBridge/functions/Config.java#L308)), so every installation created before the rename has the old absolute path stored in its settings file — including users who never chose a custom directory.
2. The migration runs **before** the settings are loaded ([`MainMenu.java#L133-L134`](https://github.com/Rdiger-36/StudioBridge/blob/main/src/main/java/rdiger36/StudioBridge/gui/MainMenu.java#L133-L134)), so the stored old path immediately overrides the migrated one.

`getAllProfiles()` then calls `mkdirs()` on that missing directory ([`MainMenu.java#L1141-L1143`](https://github.com/Rdiger-36/StudioBridge/blob/main/src/main/java/rdiger36/StudioBridge/gui/MainMenu.java#L1141-L1143)) and silently shows an empty list. This forms a loop that repeats forever:

| Step | Result |
|---|---|
| User saves a profile | written to `~/StudioBridge/Profiles` |
| Exit | settings store the old path again |
| Next start | migration moves the profile to `~/.studio-bridge/Profiles` and deletes `~/StudioBridge` |
| Settings loaded | path points back to `~/StudioBridge/Profiles` → recreated empty → profile gone from the list |

This matches the reporter's observation that "the folder is unlinked/recreated every time StudioBridge starts".

## Fix

Remap the profiles path onto the current data directory *after* the settings have been loaded. Doing it inside `migrateOldDataDirectory()` would not work, because the settings are read afterwards and would overwrite the result.

The remapping:

- **does not require the old directory to exist** — that is exactly the state the loop leaves behind, since the migration deletes it and `getAllProfiles()` recreates it empty;
- **is idempotent**, so running it on every start is safe (settings are only persisted on exit, so a hard shutdown must not leave the user stuck);
- **keeps directories outside the old data directory untouched**, so a location the user deliberately selected is not affected;
- **compares including the path separator**, so a sibling such as `~/StudioBridgeBackup` is not matched;
- **runs before the CLI arguments are parsed**, so an explicit `--customProfilesDir` still wins.

## Tests

Added `MainMenuTest` covering the remapping: the reported default-path case, the legacy directory itself, nested directories, custom directories elsewhere, the shared-prefix sibling, idempotency and `null`.

## Verification

Reproduced and fixed on macOS with the 2.1.2 release build. Before the fix, every start recreated an empty `~/StudioBridge/Profiles` while the profiles sat unused in `~/.studio-bridge/Profiles`. With the path corrected, `~/StudioBridge` stays deleted after the migration and the existing profiles load again.

Note for existing users: the "Reset to default" workaround from the issue thread keeps working; this change simply makes it unnecessary.

