### PR TITLE
chore(ci): bump artifact actions to v7 for Node 24 runtime

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -48,12 +48,12 @@ jobs:
           cp target/*-jar-with-dependencies.jar input/${{ env.MAIN_JAR }}
           cp target/*-jar-with-dependencies.jar "target/StudioBridge-${{ steps.version.outputs.value }}.jar"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: jar-release
           path: target/StudioBridge-*.jar
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: jar-input
           path: input/StudioBridge.jar
@@ -93,7 +93,7 @@ jobs:
           echo "$wixDir" >> $env:GITHUB_PATH
 
       - name: Download JAR
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: jar-input
           path: input
@@ -168,7 +168,7 @@ jobs:
           Get-ChildItem msi-output\*.msi |
             Move-Item -Destination "StudioBridge-${v}_win_${{ matrix.arch }}.msi"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: windows-${{ matrix.arch }}
           path: |
@@ -209,7 +209,7 @@ jobs:
           chmod +x appimagetool
 
       - name: Download JAR
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: jar-input
           path: input
@@ -283,7 +283,7 @@ jobs:
             ./appimagetool "${APPDIR}" \
             "${{ env.APP_NAME }}-${VERSION}-${{ matrix.arch }}.AppImage"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: linux-${{ matrix.arch }}
           path: "*.AppImage"
@@ -338,7 +338,7 @@ jobs:
       # icon.icns is pre-converted and stored in .github/packaging/icons/
 
       - name: Download JAR
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: jar-input
           path: input
@@ -453,7 +453,7 @@ jobs:
 
           xcrun stapler staple "$DMG"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: macos-arm64
           path: "*.dmg"
@@ -470,7 +470,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary

Follow-up to #36. That PR bumped the artifact actions to `v5`, but GitHub still flagged a Node 20 deprecation warning on the `build-jar` job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@v5

Turns out `v5` still runs on Node 20 for these two:

| Action | node20 up to | node24 from |
|---|---|---|
| `actions/upload-artifact` | v5 | v6+ |
| `actions/download-artifact` | v5, v6 | v7+ |

This bumps both to **v7** — the lowest common major where both run on Node 24, keeping upload and download on a matching version. All v4+ releases share the same immutable-artifacts backend, so cross-job upload/download stays compatible.

`checkout@v5` and `setup-java@v5` already run on Node 24 and are left unchanged.

## Warning resolved

- `Node.js 20 is deprecated ... actions/upload-artifact@v5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)