### PR TITLE
chore(release): bump version to 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To use StudioBridge via Terminal/CMD/PowerShell you have to run the StudioBridge
 
 /Applications/StudioBridge.app/Contents/MacOS/StudioBridgeCLI --help
 
-*** StudioBridge by Rdiger-36 v.2.1.2 ***
+*** StudioBridge by Rdiger-36 v.2.1.3 ***
 
 Usage:
   /Applications/StudioBridge.app/Contents/MacOS/StudioBridgeCLI [OPTIONS]
@@ -122,7 +122,7 @@ You can find the StudioBridgeCLI.exe in your installation directory, standard: "
 ```bash
 .\StudioBridgeCLI.exe --help
 
-*** StudioBridge by Rdiger-36 v.2.1.2 ***
+*** StudioBridge by Rdiger-36 v.2.1.3 ***
 
 You are currently running this application in raw mode (via .jar)!
 For the official version for your OS and CPU architecture, please visit the GitHub repository.
@@ -158,7 +158,7 @@ Example:
 ```bash
 .\StudioBridge.AppImage --help
 
-*** StudioBridge by Rdiger-36 v.2.1.2 ***
+*** StudioBridge by Rdiger-36 v.2.1.3 ***
 
 You are currently running this application in raw mode (via .jar)!
 For the official version for your OS and CPU architecture, please visit the GitHub repository.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>rdiger36</groupId>
     <artifactId>StudioBridge</artifactId>
-    <version>2.1.2</version>
+    <version>2.1.3</version>
     <packaging>jar</packaging>
 
     <name>StudioBridge</name>

--- a/src/main/java/rdiger36/StudioBridge/gui/MainMenu.java
+++ b/src/main/java/rdiger36/StudioBridge/gui/MainMenu.java
@@ -72,7 +72,7 @@ public class MainMenu {
     public static String title = "StudioBridge";
     
     // Application version
-    public static String version = "212";
+    public static String version = "213";
     
     // Destination for UDPPackage
     public static String destionation4UDP = "localhost";


### PR DESCRIPTION
## Summary

Bumps the application version from `2.1.2` to `2.1.3` across all three places it lives:

- `pom.xml` — Maven `<version>`
- `MainMenu.java` — runtime version constant (`"212"` → `"213"`)
- `README.md` — three example output banners

## Notes

The format-example comment in `Update.java` is left untouched — it only illustrates version-string formats, not the current version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)